### PR TITLE
UPL-T1273: Show discount percentage in leads group chip

### DIFF
--- a/src/app/components/leads/leads.component.html
+++ b/src/app/components/leads/leads.component.html
@@ -54,7 +54,7 @@
             <fs-chip
                 [size]="'small'"
                 [backgroundColor]="group.color">
-              {{ group.name }}
+              {{ group.name }}@if (group.discount) { · {{ group.discount }}%}
             </fs-chip>
           }
         </fs-chips>


### PR DESCRIPTION
## Summary
- Display the group discount percentage alongside the group name in the CRM leads lister chips
- Format: `Group Name · 15%`
- Groups with no discount continue to show just the group name

## Test plan
- [ ] Verify leads with groups that have a discount show the format `Group Name · 15%`
- [ ] Verify leads with groups that have no discount (null or 0) show just `Group Name`
- [ ] Verify chip styling and spacing looks correct with the added text

🤖 Generated with [Claude Code](https://claude.com/claude-code)